### PR TITLE
use session state to continue displaying spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 __pycache__/
+.DS_Store


### PR DESCRIPTION
This bug was caused by conditionally rendering a spreadsheet. Because we did not save to the session state that the user had clicked the `run` button, whenever the app updated (as a result of using Mito, ie) the app re-rendered without displaying Mito. 

Test by 
1. Recreating the bug on the main branch
2. Using this branch and seeing bug is fixed

Follow this procedure:
1. Create a new automation and save it
2. Rerun the automation on the `rerun` tab
3. Load the unique values of a column. Previously, the spreadsheet would disappear. Now, the spreadsheet does not! 