### PR TITLE
give inputs unique keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 venv/
 __pycache__/
+.DS_Store
+automations/

--- a/app.py
+++ b/app.py
@@ -94,17 +94,17 @@ with consume_tab:
     updated_metadata = {}
 
     # Loop through the parameters in the analysis to display imports
-    for param in analysis.get_param_metadata():
+    for idx, param in enumerate(analysis.get_param_metadata()):
         new_param = None
 
         # For imports that are exports, display a text input
         if param['subtype'] in ['file_name_export_excel', 'file_name_export_csv']:
-            new_param = st.text_input(param['name'], value=param['original_value'])
+            new_param = st.text_input(param['name'], value=param['original_value'], key=idx)
             
         # For imports that are file imports, display a file uploader
         elif param['subtype'] in ['file_name_import_excel', 'file_name_import_csv']:
             file_path = os.path.basename(param['original_value'])
-            new_param = st.file_uploader(file_path)
+            new_param = st.file_uploader(file_path, key=idx)
         
         if new_param is not None:
             updated_metadata[param['name']] = new_param


### PR DESCRIPTION
Fixes a bug where if you had uploaded the same file twice or the two different sheets from the same Excel file, the streamlit app would error because the file browsers would have the same keys. 

Also, updated the Streamlit example docs here: https://docs.trymito.io/mito-for-streamlit/api-reference/runnableanalysis-class#example-usage-1