### PR TITLE
add description to automations

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import streamlit as st
 import pandas as pd 
 from mitosheet.streamlit.v1 import spreadsheet, RunnableAnalysis
 import os
-from file_utils import save_analysis, get_all_provider_names_from_automations, get_runnable_analysis_from_provider_name
+from file_utils import save_analysis, get_all_provider_names_from_automations, get_runnable_analysis_and_description_from_provider_name
 
 # Set the streamlit page to wide so you can see the whole spreadsheet
 st.set_page_config(layout="wide")
@@ -51,6 +51,7 @@ consume_tab, create_tab = st.tabs(["Use Existing Automation", "Start New Automat
 with create_tab:
 
     provider_name = st.text_input("Provider Name", value="")
+    description = st.text_area("Automation Description. Remind yourself which data to import in the future and the purpose of the automation.", value="")
 
     # Create an empty spreadsheet
     analysis: RunnableAnalysis = spreadsheet(
@@ -64,7 +65,11 @@ with create_tab:
             st.warning("Please enter a provider name before saving")
             st.stop()
 
-        saved, error_message = save_analysis(provider_name, analysis)
+        if description == '':
+            st.warning("Please enter a description before saving")
+            st.stop()
+
+        saved, error_message = save_analysis(provider_name, analysis, description)
 
         if not saved:
             st.error(error_message)        
@@ -86,7 +91,9 @@ with consume_tab:
         st.stop()
 
     # Get the analysis from the provider name
-    analysis = get_runnable_analysis_from_provider_name(provider_name)
+    analysis, description = get_runnable_analysis_and_description_from_provider_name(provider_name)
+
+    st.info(f"Automation Description: {description}")
 
     st.markdown("### Upload the new BOB files")
 

--- a/file_utils.py
+++ b/file_utils.py
@@ -20,7 +20,8 @@ def get_file_name_from_provider_name(provider_name):
 
 def save_analysis(
         provider_name,
-        analysis
+        analysis,
+        description,
     ):
 
     if not os.path.exists(os.path.join(os.getcwd(), 'automations')):
@@ -38,6 +39,7 @@ def save_analysis(
             "mitosheet_version": mitosheet_version,
             "user": getpass.getuser(),
             "creation_time": str(datetime.datetime.now()),
+            "description": description
         }))
 
     return True, None
@@ -62,10 +64,18 @@ def get_all_provider_names_from_automations():
 
     return providers
 
-def get_runnable_analysis_from_provider_name(provider_name):
+def get_runnable_analysis_and_description_from_provider_name(provider_name):
     file_name = get_file_name_from_provider_name(provider_name)
     file_path = os.path.join(os.getcwd(), 'automations', file_name)
     with open(file_path, 'r') as f:
         json_string = f.read()
 
-    return RunnableAnalysis.from_json(json.loads(json_string)['analysis'])
+
+    automation_json = json.loads(json_string)
+    analysis = RunnableAnalysis.from_json(automation_json['analysis'])
+
+    # The description key was added in a later release of the app, 
+    # so we first check that the description exists before trying to read it
+    description =  automation_json['description'] if 'description' in automation_json else "No description provided for this automation"
+
+    return analysis, description


### PR DESCRIPTION
Adds a required description to automations to make it easier for app users to remember how to rerun the automation in the future. Best practices is to add an explanation of which data to upload the next time you run it. 

Test that this PR will not break existing automations by creating an automation on the main branch first and then rerunning it on this branch. 